### PR TITLE
Enable Vault integration (with sidecar)

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -96,3 +96,6 @@ fasitResources:
     resourceType: applicationProperties
 
 webproxy: true
+vault:
+  enabled: true
+  sidecar: true


### PR DESCRIPTION
This should inject a vault token into the app, and auto-refresh it regularly via the sidecar.

The purpose is to allow Basta to write secrets to vault, as well as to fasit.